### PR TITLE
Change owncloud max-version to 10

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
     <documentation>https://github.com/leizh/owncloud-files_clipboard</documentation>
     <screenshot>https://raw.githubusercontent.com/leizh/owncloud-files_clipboard/master/appinfo/screenshot.gif</screenshot>
     <dependencies>
-        <owncloud min-version="9.0" max-version="10.0" />
+        <owncloud min-version="9.0" max-version="10" />
         <nextcloud min-version="12" max-version="12" />
         <php min-version="5.4" max-version="7.9" />
     </dependencies>


### PR DESCRIPTION
Due to owncloud implementing semver. If the app works with 10.0.* (e.g. if it is currently working with 10.0.9 and 10.0.10) then it will work with 10.1.* 10.2.* etc because that is what is being promised with semver - upward-backward-compatibility that is only broken by a major release 11.